### PR TITLE
remove deprecated command for generating the db

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
-    "db:generate": "drizzle-kit generate:pg",
+    "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx migrate.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Change the script command for `db:generate` from `drizzle-kit generate:pg `to `drizzle-kit generate`

https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210

